### PR TITLE
Merge several changes from the ReNoM's fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Qt / QML REST Client  (Beta)
 
+**NOTE: the last changes break the compatibility with the previous versions of the library. See the `expand` parameter.**
+
 Qt REST Client  - small and simple REST API client for any Qt/QML application.
 Library support standard JSON and XML REST APIs and auto mapping REST data to QAbstractListModel for QML
 
@@ -49,7 +51,22 @@ mkdir PROJECT_ROOT/api/
 cd PROJECT_ROOT/api/
 git clone https://github.com/kafeg/qtrest.git
 ```
-Then add `include (api/qtrest/com_github_qtrest.pri)` to your project file.
+If you're using qmake, just add `include (api/qtrest/com_github_qtrest.pri)` to the .pro file.
+
+For Qbs, please make the following adjustments inside the .qbs file:
+```
+import qbs
+
+Project {
+    ...
+    references: "qtrest/com_github_kafeg_qtrest.qbs"
+    Product {
+        ...
+        Depends { name: "qtrest" }
+        ...
+    }
+}
+```
 
 #### 2. Create your own API class
 After setup library we must create class API inherited from existing APIBase, e.g. `api/api.h` and `api/api.cpp`:
@@ -433,7 +450,7 @@ ListView {
 ## Advanced usage
 
 #### 1. DetailsView page
-Also, we have full support for StackView navigation by special 'details model' available in each your model, based on QSortFilterModel and using 'ID' field as filter. For example, we have ListView in one Stack element, and DrtailView in other stack element.
+Also, we have full support for StackView navigation by special 'details model' available in each your model, based on QSortFilterModel and using 'ID' field as filter. For example, we have ListView in one Stack element, and DetailView in other stack element.
 We may fetch details info for one of elements and send this element into Details page, when we may use simple hack for display one element with detail info:
 ``` QML
 import QtQuick 2.6
@@ -498,4 +515,45 @@ Item {
     }
 }
 ```
-In this code we open Detail page, waitng for loading details info with BusyIndicator displaying, and after loading complete - display full information for item. Our hack is in ListView, it will be not interactive and display only one item.
+In this code we open Detail page, waiting for loading details info with BusyIndicator displaying, and after loading complete - display full information for item. Our hack is in ListView, it will be not interactive and display only one item.
+
+It's also possible to create a details page without `ListView`. In this case, the above examples come with the following changes:
+1. You have to pass the `couponsModel.details` property instead of `couponsModel.detailsModel`:
+``` QML
+...
+stackView.push(couponsList.detailSource,
+{details: couponsModel.details,
+couponsModel: couponsModel})
+...
+```
+And the changes for the details page:
+``` QML
+...
+property var details
+...
+```
+2. Then, you have to implement the `detailComponent` component in a shorter form:
+``` QML
+...
+Component {
+    id: detailComponent
+
+    ItemDelegate {
+        width: couponsList.width;
+        anchors.horizontalCenter: parent.horizontalCenter
+    }
+}
+...
+```
+Thus, you can directly access any property of the details model (without `ListView`). E.g. - `details.title` in the following example:
+``` QML
+...
+Component {
+    id: detailComponent
+
+    Label {
+        text: details.title
+    }
+}
+...
+```

--- a/com_github_kafeg_qtrest.qbs
+++ b/com_github_kafeg_qtrest.qbs
@@ -1,0 +1,40 @@
+import qbs
+
+StaticLibrary {
+    name: "qtrest"
+    Depends { name: 'cpp' }
+    Depends { name: "Qt.network" }
+    Depends { name: "Qt.qml" }
+    files: [
+        "src/apibase.h",
+        "src/models/baserestlistmodel.h",
+        "src/models/detailsmodel.h",
+        "src/models/restitem.h",
+        "src/usingleton.h",
+        "src/models/pagination.h",
+        "src/models/abstractjsonrestlistmodel.h",
+        "src/models/abstractxmlrestlistmodel.h",
+        "src/models/jsonrestlistmodel.h",
+        "src/models/requests.h",
+        "src/models/xmlrestlistmodel.h",
+        "src/apibase.cpp",
+        "src/models/baserestlistmodel.cpp",
+        "src/models/detailsmodel.cpp",
+        "src/models/restitem.cpp",
+        "src/models/pagination.cpp",
+        "src/models/abstractjsonrestlistmodel.cpp",
+        "src/models/abstractxmlrestlistmodel.cpp",
+        "src/models/jsonrestlistmodel.cpp",
+        "src/models/requests.cpp",
+        "src/models/xmlrestlistmodel.cpp",
+        "com_github_kafeg_qtrest.qrc",
+        "README.md",
+        "LICENSE",
+        "docs/QtMicroRestFramework.qmodel"
+    ]
+    cpp.includePaths: ["src", "src/models"]
+    Export {
+        Depends { name: "cpp" }
+        cpp.includePaths: ["src", "src/models"]
+    }
+}

--- a/src/apibase.cpp
+++ b/src/apibase.cpp
@@ -137,6 +137,16 @@ QNetworkReply *APIBase::get(QUrl url)
     return reply;
 }
 
+QNetworkReply *APIBase::post(QUrl url)
+{
+    QNetworkRequest request = createRequest(url);
+    setRawHeaders(&request);
+
+    QNetworkReply *reply = manager->sendCustomRequest(request, "POST");
+    connectReplyToErrors(reply);
+    return reply;
+}
+
 QNetworkReply *APIBase::post(QUrl url, QIODevice *data)
 {
     QNetworkRequest request = createRequest(url);
@@ -163,6 +173,16 @@ QNetworkReply *APIBase::post(QUrl url, QHttpMultiPart *multiPart)
     setRawHeaders(&request);
 
     QNetworkReply *reply = manager->post(request, multiPart);
+    connectReplyToErrors(reply);
+    return reply;
+}
+
+QNetworkReply *APIBase::put(QUrl url)
+{
+    QNetworkRequest request = createRequest(url);
+    setRawHeaders(&request);
+
+    QNetworkReply *reply = manager->sendCustomRequest(request, "PUT");
     connectReplyToErrors(reply);
     return reply;
 }
@@ -197,6 +217,46 @@ QNetworkReply *APIBase::put(QUrl url, QHttpMultiPart *multiPart)
     return reply;
 }
 
+QNetworkReply *APIBase::patch(QUrl url)
+{
+    QNetworkRequest request = createRequest(url);
+    setRawHeaders(&request);
+
+    QNetworkReply *reply = manager->sendCustomRequest(request, "PATCH");
+    connectReplyToErrors(reply);
+    return reply;
+}
+
+QNetworkReply *APIBase::patch(QUrl url, QIODevice *data)
+{
+    QNetworkRequest request = createRequest(url);
+    setRawHeaders(&request);
+
+    QNetworkReply *reply = manager->sendCustomRequest(request, "PATCH", data);
+    connectReplyToErrors(reply);
+    return reply;
+}
+
+QNetworkReply *APIBase::patch(QUrl url, const QByteArray &data)
+{
+    QNetworkRequest request = createRequest(url);
+    setRawHeaders(&request);
+
+    QNetworkReply *reply = manager->sendCustomRequest(request, "PATCH", data);
+    connectReplyToErrors(reply);
+    return reply;
+}
+
+QNetworkReply *APIBase::patch(QUrl url, QHttpMultiPart *multiPart)
+{
+    QNetworkRequest request = createRequest(url);
+    setRawHeaders(&request);
+
+    QNetworkReply *reply = manager->sendCustomRequest(request, "PATCH", multiPart);
+    connectReplyToErrors(reply);
+    return reply;
+}
+
 QNetworkReply *APIBase::deleteResource(QUrl url)
 {
     QNetworkRequest request = createRequest(url);
@@ -222,17 +282,7 @@ QNetworkReply *APIBase::options(QUrl url)
     QNetworkRequest request = createRequest(url);
     setRawHeaders(&request);
 
-    QNetworkReply *reply = manager->sendCustomRequest(request,"OPTIONS");
-    connectReplyToErrors(reply);
-    return reply;
-}
-
-QNetworkReply *APIBase::patch(QUrl url)
-{
-    QNetworkRequest request = createRequest(url);
-    setRawHeaders(&request);
-
-    QNetworkReply *reply = manager->sendCustomRequest(request,"PATCH");
+    QNetworkReply *reply = manager->sendCustomRequest(request, "OPTIONS");
     connectReplyToErrors(reply);
     return reply;
 }

--- a/src/apibase.cpp
+++ b/src/apibase.cpp
@@ -2,7 +2,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 
-APIBase::APIBase(QObject *parent) : QObject(parent), m_acceptHeader("Accept"), m_authTokenHeader("Authorization")
+APIBase::APIBase(QObject *parent) : QObject(parent), m_acceptHeader("Accept"), m_contentTypeHeader("Content-Type"), m_authTokenHeader("Authorization")
 {
     manager = new QNetworkAccessManager(this);
 
@@ -69,6 +69,16 @@ QByteArray APIBase::acceptHeader() const
     return m_acceptHeader;
 }
 
+QByteArray APIBase::contentType() const
+{
+    return m_contentType;
+}
+
+QByteArray APIBase::contentTypeHeader() const
+{
+    return m_contentTypeHeader;
+}
+
 QByteArray APIBase::authToken() const
 {
     return m_authToken;
@@ -107,6 +117,27 @@ void APIBase::setAcceptHeader(QByteArray acceptHeader)
 
     m_acceptHeader = acceptHeader;
     emit acceptHeaderChanged(acceptHeader);
+}
+
+void APIBase::setContentType(QString contentType)
+{
+    QByteArray newData;
+    newData.append(contentType);
+
+    if (m_contentType == newData)
+        return;
+
+    m_contentType = newData;
+    emit contentTypeChanged(newData);
+}
+
+void APIBase::setContentTypeHeader(QByteArray contentTypeHeader)
+{
+    if (m_contentTypeHeader == contentTypeHeader)
+        return;
+
+    m_contentTypeHeader = contentTypeHeader;
+    emit contentTypeHeaderChanged(contentTypeHeader);
 }
 
 void APIBase::setAuthToken(QByteArray authToken)
@@ -161,6 +192,9 @@ QNetworkReply *APIBase::post(QUrl url,const QByteArray &data)
 {
     QNetworkRequest request = createRequest(url);
     setRawHeaders(&request);
+    if (!contentType().isEmpty()) {
+        request.setRawHeader(contentTypeHeader(), contentType());
+    }
 
     QNetworkReply *reply = manager->post(request, data);
     connectReplyToErrors(reply);
@@ -201,6 +235,9 @@ QNetworkReply *APIBase::put(QUrl url, const QByteArray &data)
 {
     QNetworkRequest request = createRequest(url);
     setRawHeaders(&request);
+    if (!contentType().isEmpty()) {
+        request.setRawHeader(contentTypeHeader(), contentType());
+    }
 
     QNetworkReply *reply = manager->put(request, data);
     connectReplyToErrors(reply);
@@ -241,6 +278,9 @@ QNetworkReply *APIBase::patch(QUrl url, const QByteArray &data)
 {
     QNetworkRequest request = createRequest(url);
     setRawHeaders(&request);
+    if (!contentType().isEmpty()) {
+        request.setRawHeader(contentTypeHeader(), contentType());
+    }
 
     QNetworkReply *reply = manager->sendCustomRequest(request, "PATCH", data);
     connectReplyToErrors(reply);

--- a/src/apibase.cpp
+++ b/src/apibase.cpp
@@ -182,6 +182,9 @@ QNetworkReply *APIBase::post(QUrl url, QIODevice *data)
 {
     QNetworkRequest request = createRequest(url);
     setRawHeaders(&request);
+    if (!contentType().isEmpty()) {
+        request.setRawHeader(contentTypeHeader(), contentType());
+    }
 
     QNetworkReply *reply = manager->post(request, data);
     connectReplyToErrors(reply);
@@ -225,6 +228,9 @@ QNetworkReply *APIBase::put(QUrl url, QIODevice *data)
 {
     QNetworkRequest request = createRequest(url);
     setRawHeaders(&request);
+    if (!contentType().isEmpty()) {
+        request.setRawHeader(contentTypeHeader(), contentType());
+    }
 
     QNetworkReply *reply = manager->put(request, data);
     connectReplyToErrors(reply);
@@ -268,6 +274,9 @@ QNetworkReply *APIBase::patch(QUrl url, QIODevice *data)
 {
     QNetworkRequest request = createRequest(url);
     setRawHeaders(&request);
+    if (!contentType().isEmpty()) {
+        request.setRawHeader(contentTypeHeader(), contentType());
+    }
 
     QNetworkReply *reply = manager->sendCustomRequest(request, "PATCH", data);
     connectReplyToErrors(reply);

--- a/src/apibase.h
+++ b/src/apibase.h
@@ -36,12 +36,14 @@ public:
 
     virtual QNetworkReply *handleRequest(QString path, QStringList sort, Pagination *pagination,
                                          QVariantMap filters = QVariantMap(),
-                                         QStringList fields = QStringList(), QString id = 0) {
+                                         QStringList fields = QStringList(), QStringList expand = QStringList(),
+                                         QString id = 0) {
         Q_UNUSED(path)
         Q_UNUSED(sort)
         Q_UNUSED(pagination)
         Q_UNUSED(filters)
         Q_UNUSED(fields)
+        Q_UNUSED(expand)
         Q_UNUSED(id)
         return 0;
     };

--- a/src/apibase.h
+++ b/src/apibase.h
@@ -20,6 +20,8 @@ public:
     //Accept header for JSON/XML data
     Q_PROPERTY(QByteArray accept READ accept WRITE setAccept NOTIFY acceptChanged)
     Q_PROPERTY(QByteArray acceptHeader READ acceptHeader WRITE setAcceptHeader NOTIFY acceptHeaderChanged)
+    Q_PROPERTY(QByteArray contentType READ contentType WRITE setContentType NOTIFY contentTypeChanged)
+    Q_PROPERTY(QByteArray contentTypeHeader READ contentTypeHeader WRITE setContentTypeHeader NOTIFY contentTypeHeaderChanged)
     //Specify Auth token for each request. Set this before run your requests (You may use Basic auth and Bearer token auth)
     Q_PROPERTY(QByteArray baseUrl READ baseUrl WRITE setBaseUrl NOTIFY baseUrlChanged)
     //Specify Auth token for each request. Set this before run your requests (You may use Basic auth and Bearer token auth)
@@ -31,6 +33,8 @@ public:
     QByteArray baseUrl() const;
     QByteArray accept() const;
     QByteArray acceptHeader() const;
+    QByteArray contentType() const;
+    QByteArray contentTypeHeader() const;
     QByteArray authToken() const;
     QByteArray authTokenHeader() const;
 
@@ -52,6 +56,8 @@ public slots:
     void setBaseUrl(QByteArray baseUrl);
     void setAccept(QString accept);
     void setAcceptHeader(QByteArray acceptHeader);
+    void setContentType(QString contentType);
+    void setContentTypeHeader(QByteArray contentTypeHeader);
     void setAuthToken(QByteArray authToken);
     void setAuthTokenHeader(QByteArray authTokenHeader);
 
@@ -60,6 +66,8 @@ signals:
     void acceptChanged(QByteArray accept);
     void baseUrlChanged(QByteArray baseUrl);
     void acceptHeaderChanged(QByteArray acceptHeader);
+    void contentTypeChanged(QByteArray contentType);
+    void contentTypeHeaderChanged(QByteArray contentTypeHeader);
     void authTokenChanged(QByteArray authToken);
     void authTokenHeaderChanged(QByteArray authTokenHeader);
 
@@ -97,6 +105,8 @@ private:
     QByteArray m_accept;
     QByteArray m_baseUrl;
     QByteArray m_acceptHeader;
+    QByteArray m_contentType;
+    QByteArray m_contentTypeHeader;
     QByteArray m_authToken;
     QByteArray m_authTokenHeader;
 };

--- a/src/apibase.h
+++ b/src/apibase.h
@@ -65,16 +65,21 @@ signals:
 
 protected:
     QNetworkReply *get(QUrl url);
+    QNetworkReply *post(QUrl url);
     QNetworkReply *post(QUrl url, QIODevice *data);
     QNetworkReply *post(QUrl url, const QByteArray &data);
     QNetworkReply *post(QUrl url, QHttpMultiPart *multiPart);
+    QNetworkReply *put(QUrl url);
     QNetworkReply *put(QUrl url, QIODevice *data);
     QNetworkReply *put(QUrl url, const QByteArray &data);
     QNetworkReply *put(QUrl url, QHttpMultiPart *multiPart);
+    QNetworkReply *patch(QUrl url);
+    QNetworkReply *patch(QUrl url, QIODevice *data);
+    QNetworkReply *patch(QUrl url, const QByteArray &data);
+    QNetworkReply *patch(QUrl url, QHttpMultiPart *multiPart);
     QNetworkReply *deleteResource(QUrl url);
     QNetworkReply *head(QUrl url);
     QNetworkReply *options(QUrl url);
-    QNetworkReply *patch(QUrl url);
 
     QNetworkAccessManager *manager;
 

--- a/src/models/baserestlistmodel.cpp
+++ b/src/models/baserestlistmodel.cpp
@@ -113,13 +113,13 @@ void BaseRestListModel::fetchMoreFinished()
 
     //prepare vars
     int insertFrom = rowCount();
-    int insertCount = rowCount()+values.count()-1;
+    int insertCount = rowCount()+values.count();
 
     //check if we need to full reload
     if (this->loadingStatus() == LoadingStatus::FullReloadProcessing) {
         reset();
         insertFrom = rowCount();
-        insertCount = values.count()-1;
+        insertCount = values.count();
     }
 
     //check for assertion or empty data
@@ -133,7 +133,7 @@ void BaseRestListModel::fetchMoreFinished()
     }
 
     //append rows to model
-    beginInsertRows(this->index(rowCount(), 0), insertFrom, insertCount);
+    beginInsertRows(this->index(rowCount(), 0), insertFrom, insertCount-1);
 
     QListIterator<QVariant> i(values);
     while (i.hasNext()) {

--- a/src/models/baserestlistmodel.cpp
+++ b/src/models/baserestlistmodel.cpp
@@ -178,6 +178,11 @@ void BaseRestListModel::fetchDetail(QString id)
 
     m_detailsModel.invalidateModel();
 
+    // clean up the details model (QQmlPropertyMap)
+    for (const QString &key : m_details.keys()) {
+        m_details.clear(key);
+    }
+
     QNetworkReply *reply = fetchDetailImpl(id);
     connect(reply, SIGNAL(finished()), this, SLOT(fetchDetailFinished()));
 }
@@ -200,6 +205,13 @@ void BaseRestListModel::fetchDetailFinished()
     generateDetailsRoleNames(item);
 
     detailsModel()->setSourceModel(this);
+
+    // fill up the details model (QQmlPropertyMap)
+    QMapIterator<QString, QVariant> i(item);
+    while (i.hasNext()) {
+        i.next();
+        m_details.insert(i.key(), i.value());
+    }
 
     setLoadingStatus(LoadingStatus::IdleDetails);
 }
@@ -345,6 +357,11 @@ QString BaseRestListModel::fetchDetailLastId() const
 DetailsModel *BaseRestListModel::detailsModel()
 {
     return &m_detailsModel;
+}
+
+QQmlPropertyMap *BaseRestListModel::details()
+{
+    return &m_details;
 }
 
 Pagination *BaseRestListModel::pagination()

--- a/src/models/baserestlistmodel.cpp
+++ b/src/models/baserestlistmodel.cpp
@@ -62,6 +62,7 @@ void BaseRestListModel::fetchMore(const QModelIndex &parent)
         setLoadingStatus(LoadingStatus::FullReloadProcessing);
         break;
     case LoadingStatus::Idle:
+    case LoadingStatus::IdleDetails:
         setLoadingStatus(LoadingStatus::LoadMoreProcessing);
         break;
     default:
@@ -167,6 +168,7 @@ void BaseRestListModel::fetchDetail(QString id)
 
     switch (loadingStatus()) {
     case LoadingStatus::Idle:
+    case LoadingStatus::IdleDetails:
         setLoadingStatus(LoadingStatus::LoadDetailsProcessing);
         break;
     default:

--- a/src/models/baserestlistmodel.cpp
+++ b/src/models/baserestlistmodel.cpp
@@ -318,6 +318,11 @@ QStringList BaseRestListModel::fields() const
     return m_fields;
 }
 
+QStringList BaseRestListModel::expand() const
+{
+    return m_expand;
+}
+
 QString BaseRestListModel::idField() const
 {
     return m_idField;
@@ -475,6 +480,15 @@ void BaseRestListModel::setFields(QStringList fields)
 
     m_fields = fields;
     emit fieldsChanged(fields);
+}
+
+void BaseRestListModel::setExpand(QStringList expand)
+{
+    if (m_expand == expand)
+        return;
+
+    m_expand = expand;
+    emit expandChanged(expand);
 }
 
 void BaseRestListModel::setIdField(QString idField)

--- a/src/models/baserestlistmodel.h
+++ b/src/models/baserestlistmodel.h
@@ -30,6 +30,8 @@ public:
     Q_PROPERTY(QVariantMap filters READ filters WRITE setFilters NOTIFY filtersChanged)
     //Specify fields parameter
     Q_PROPERTY(QStringList fields READ fields WRITE setFields NOTIFY fieldsChanged)
+    //Specify expand parameter
+    Q_PROPERTY(QStringList expand READ expand WRITE setExpand NOTIFY expandChanged)
     //Specify Accept header for application/json or application/xml
     Q_PROPERTY(QByteArray accept READ accept WRITE setAccept NOTIFY acceptChanged)
 
@@ -67,6 +69,7 @@ public:
     QString loadingErrorString() const;
     QNetworkReply::NetworkError loadingErrorCode() const;
     QStringList fields() const;
+    QStringList expand() const;
     QString idField() const;
     int idFieldRole() const;
     QString fetchDetailLastId() const;
@@ -87,6 +90,7 @@ signals:
     void loadingErrorStringChanged(QString loadingErrorString);
     void loadingErrorCodeChanged(QNetworkReply::NetworkError loadingErrorCode);
     void fieldsChanged(QStringList fields);
+    void expandChanged(QStringList expand);
     void idFieldChanged(QString idField);
     void acceptChanged(QByteArray accept);
     void apiInstanceChanged(APIBase *apiInstance);
@@ -108,6 +112,7 @@ public slots:
     void setSort(QStringList sort);
     void setFilters(QVariantMap filters);
     void setFields(QStringList fields);
+    void setExpand(QStringList expand);
     void setIdField(QString idField);
 
     void setApiInstance(APIBase *apiInstance);
@@ -161,6 +166,7 @@ private:
     bool m_detailRoleNamesGenerated;
     QList<RestItem> m_items;
     QStringList m_fields;
+    QStringList m_expand;
     QString m_idField;
     QStringList m_sort;
     LoadingStatus m_loadingStatus;

--- a/src/models/baserestlistmodel.h
+++ b/src/models/baserestlistmodel.h
@@ -2,6 +2,7 @@
 #define BASERESTLISTMODEL_H
 
 #include <QAbstractListModel>
+#include <QQmlPropertyMap>
 #include "restitem.h"
 #include "pagination.h"
 #include "detailsmodel.h"
@@ -40,6 +41,7 @@ public:
     Q_PROPERTY(int idFieldRole READ idFieldRole)
     Q_PROPERTY(QString fetchDetailLastId READ fetchDetailLastId)
     Q_PROPERTY(DetailsModel *detailsModel READ detailsModel)
+    Q_PROPERTY(QQmlPropertyMap *details READ details)
 
     //load status and result code
     Q_PROPERTY(LoadingStatus loadingStatus READ loadingStatus WRITE setLoadingStatus NOTIFY loadingStatusChanged)
@@ -74,6 +76,7 @@ public:
     int idFieldRole() const;
     QString fetchDetailLastId() const;
     DetailsModel *detailsModel();
+    QQmlPropertyMap *details();
     Pagination *pagination();
     QByteArray accept();
     int count() const;
@@ -175,6 +178,7 @@ private:
     QNetworkReply::NetworkError m_loadingErrorCode;
     QString m_fetchDetailLastId;
     DetailsModel m_detailsModel;
+    QQmlPropertyMap m_details;
     Pagination m_pagination;
     APIBase *m_apiInstance;
 };

--- a/src/models/jsonrestlistmodel.cpp
+++ b/src/models/jsonrestlistmodel.cpp
@@ -8,12 +8,12 @@ JsonRestListModel::JsonRestListModel(QObject *parent) : AbstractJsonRestListMode
 QNetworkReply *JsonRestListModel::fetchMoreImpl(const QModelIndex &parent)
 {
     Q_UNUSED(parent)
-    return apiInstance()->handleRequest(requests()->get(), sort(), pagination(), filters(), fields());
+    return apiInstance()->handleRequest(requests()->get(), sort(), pagination(), filters(), fields(), expand());
 }
 
 QNetworkReply *JsonRestListModel::fetchDetailImpl(QString id)
 {
-    return apiInstance()->handleRequest(requests()->getDetails(), sort(), pagination(), filters(), fields(), id);
+    return apiInstance()->handleRequest(requests()->getDetails(), sort(), pagination(), filters(), fields(), expand(), id);
 }
 
 QVariantMap JsonRestListModel::preProcessItem(QVariantMap item)

--- a/src/models/xmlrestlistmodel.cpp
+++ b/src/models/xmlrestlistmodel.cpp
@@ -8,12 +8,12 @@ XmlRestListModel::XmlRestListModel()
 QNetworkReply *XmlRestListModel::fetchMoreImpl(const QModelIndex &parent)
 {
     Q_UNUSED(parent)
-    return apiInstance()->handleRequest(requests()->get(), sort(), pagination(), filters(), fields());
+    return apiInstance()->handleRequest(requests()->get(), sort(), pagination(), filters(), fields(), expand());
 }
 
 QNetworkReply *XmlRestListModel::fetchDetailImpl(QString id)
 {
-    return apiInstance()->handleRequest(requests()->getDetails(), sort(), pagination(), filters(), fields(), id);
+    return apiInstance()->handleRequest(requests()->getDetails(), sort(), pagination(), filters(), fields(), expand(), id);
 }
 
 QVariantMap XmlRestListModel::preProcessItem(QVariantMap item)


### PR DESCRIPTION
The full list of changes:
1. The `expand` parameter is added.
2. The additional methods to send requests were added (PATCH with data, POST/PUT without data).
3. The additional properties to set up the Content-Type request header were added (applicable only to the QByteArray and the QIODevice data).
4. The additional property to hold the details data. This property is an instance of QQmlPropertyMap.
5. Support for the Qbs build tool.
6. Bugfixes.