### PR TITLE
Mark BaseRestListModel::pagination as CONSTANT

### DIFF
--- a/src/models/baserestlistmodel.h
+++ b/src/models/baserestlistmodel.h
@@ -27,7 +27,7 @@ public:
     Q_PROPERTY(QStringList sort READ sort WRITE setSort NOTIFY sortChanged)
 
     //Specify pagination
-    Q_PROPERTY(Pagination *pagination READ pagination)
+    Q_PROPERTY(Pagination *pagination READ pagination CONSTANT)
     //Specify filters parametres
     Q_PROPERTY(QVariantMap filters READ filters WRITE setFilters NOTIFY filtersChanged)
     //Specify fields parameter


### PR DESCRIPTION
This allows one to use use a model's pagination in QML property
bindings without the following warning:

    QQmlExpression: Expression qrc:/main.qml:16:13 depends on non-NOTIFYable properties:
        JsonRestListModel::pagination